### PR TITLE
feat: add support for raw (non-Event) messages

### DIFF
--- a/events_lib_py/config.py
+++ b/events_lib_py/config.py
@@ -14,6 +14,7 @@ DEFAULTS = {
         "max_retries_per_event_map": {},
         "dlq_pre_send_hook": None,
         "generic_exception_handler": None,
+         "topic_event_name_map": {},
     },
     "PRODUCER_CONFIG": {
         "bootstrap_servers": "127.0.0.1:9092",
@@ -49,6 +50,7 @@ def load_consumer_config() -> dict:
         "max_retries_per_event_map",
         "dlq_pre_send_hook",
         "generic_exception_handler",
+        "topic_event_name_map"
     ]
     for prop in importable_props:
         if (path := config.get(prop)) and isinstance(path, str):

--- a/events_lib_py/config.py
+++ b/events_lib_py/config.py
@@ -15,7 +15,7 @@ DEFAULTS = {
         "max_retries_per_event_map": {},
         "dlq_pre_send_hook": None,
         "generic_exception_handler": None,
-         "topic_event_name_map": {},
+        "skip_unmarshal_topics_event_name_map": {},
     },
     "PRODUCER_CONFIG": {
         "bootstrap_servers": "127.0.0.1:9092",
@@ -51,7 +51,7 @@ def load_consumer_config() -> dict:
         "max_retries_per_event_map",
         "dlq_pre_send_hook",
         "generic_exception_handler",
-        "topic_event_name_map",
+        "skip_unmarshal_topics_event_name_map",
     }
     for prop in importable_props:
         if (path := config.get(prop)) and isinstance(path, str):

--- a/events_lib_py/consumer.py
+++ b/events_lib_py/consumer.py
@@ -123,20 +123,20 @@ class _KafkaConsumerHandlerMixin:
         key = msg.key().decode()
         topic = msg.topic()
         LOGGER.info("msg=%s key=%s", "Processing message", key)
-        
-        try:
-            if self._config.skip_unmarshal_topics_event_name_map and topic in self._config.skip_unmarshal_topics_event_name_map:
-                event_name = self._config.skip_unmarshal_topics_event_name_map[topic]
-                event = Event(name=event_name, payload=msg.value(), retry_count=0)
-            else: 
+
+        if self._config.skip_unmarshal_topics_event_name_map and topic in self._config.skip_unmarshal_topics_event_name_map:
+            event_name = self._config.skip_unmarshal_topics_event_name_map[topic]
+            event = Event(name=event_name, payload=msg.value(), retry_count=0)
+        else:
+            try:
                 event: Event = Event.FromString(msg.value())
-        except Exception as e:
-            self._handle_dlq(
-                msg=msg,
-                err_msg=f"Unable to parse event and no mapping found for topic {topic}",
-                exc=e,
-            )
-            return
+            except Exception as e:
+                self._handle_dlq(
+                    msg=msg,
+                    err_msg=f"Unable to parse event and no mapping found for topic {topic}",
+                    exc=e,
+                )
+                return
 
         handler = self._config.event_handler_map.get(event.name)
         if handler is None:

--- a/events_lib_py/consumer.py
+++ b/events_lib_py/consumer.py
@@ -28,7 +28,7 @@ class KafkaConsumerConfig:
     dlq_topic: str
     event_handler_map: "dict[str, Callable[[str, bytes], EventHandlerResponse]]"
     max_retries_per_event_map: "dict[str, int]"
-    topic_event_name_map: Optional[dict[str, str]] = None
+    skip_unmarshal_topics_event_name_map: Optional[dict[str, str]] = None
 
 
     bootstrap_servers: str = "127.0.0.1:9092"
@@ -123,26 +123,20 @@ class _KafkaConsumerHandlerMixin:
         key = msg.key().decode()
         topic = msg.topic()
         LOGGER.info("msg=%s key=%s", "Processing message", key)
-
+        
         try:
-            event: Event = Event.FromString(msg.value())
-        except Exception as e:
-            if self._config.topic_event_name_map and topic in self._config.topic_event_name_map:
-                event_name = self._config.topic_event_name_map[topic]
-                LOGGER.info(
-                    "msg=%s topic=%s event_name=%s",
-                    "Wrapping raw payload into Event using mapping",
-                    topic,
-                    event_name,
-                )
+            if self._config.skip_unmarshal_topics_event_name_map and topic in self._config.skip_unmarshal_topics_event_name_map:
+                event_name = self._config.skip_unmarshal_topics_event_name_map[topic]
                 event = Event(name=event_name, payload=msg.value(), retry_count=0)
-            else:
-                self._handle_dlq(
-                    msg=msg,
-                    err_msg=f"Unable to parse event and no mapping found for topic {topic}",
-                    exc=e,
-                )
-                return
+            else: 
+                event: Event = Event.FromString(msg.value())
+        except Exception as e:
+            self._handle_dlq(
+                msg=msg,
+                err_msg=f"Unable to parse event and no mapping found for topic {topic}",
+                exc=e,
+            )
+            return
 
         handler = self._config.event_handler_map.get(event.name)
         if handler is None:

--- a/events_lib_py/consumer.py
+++ b/events_lib_py/consumer.py
@@ -133,15 +133,14 @@ class _KafkaConsumerHandlerMixin:
                     topic,
                     event_name,
                 )
-                retry_count = self._config.max_retries_per_event_map.get(event_name, 0)
-                event = Event(name=event_name, payload=msg.value(), retry_count=retry_count)
+                event = Event(name=event_name, payload=msg.value(), retry_count=0)
             else:
                 self._handle_dlq(
                     msg=msg,
                     err_msg=f"Unable to parse event and no mapping found for topic {topic}",
                     exc=e,
                 )
-            return
+                return
 
         handler = self._config.event_handler_map.get(event.name)
         if handler is None:

--- a/events_lib_py/consumer.py
+++ b/events_lib_py/consumer.py
@@ -28,6 +28,8 @@ class KafkaConsumerConfig:
     dlq_topic: str
     event_handler_map: "dict[str, Callable[[str, bytes], EventHandlerResponse]]"
     max_retries_per_event_map: "dict[str, int]"
+    topic_event_name_map: Optional[dict[str, str]] = None
+
 
     bootstrap_servers: str = "127.0.0.1:9092"
     enable_ssl: bool = True
@@ -117,16 +119,28 @@ class _KafkaConsumerHandlerMixin:
             If dlq, pushes event to DLQ topic
         """
         key = msg.key().decode()
+        topic = msg.topic()
         LOGGER.info("msg=%s key=%s", "Processing message", key)
 
         try:
             event: Event = Event.FromString(msg.value())
         except Exception as e:
-            self._handle_dlq(
-                msg=msg,
-                err_msg="Unable to parse event",
-                exc=e,
-            )
+            if self._config.topic_event_name_map and topic in self._config.topic_event_name_map:
+                event_name = self._config.topic_event_name_map[topic]
+                LOGGER.info(
+                    "msg=%s topic=%s event_name=%s",
+                    "Wrapping raw payload into Event using mapping",
+                    topic,
+                    event_name,
+                )
+                retry_count = self._config.max_retries_per_event_map.get(event_name, 0)
+                event = Event(name=event_name, payload=msg.value(), retry_count=retry_count)
+            else:
+                self._handle_dlq(
+                    msg=msg,
+                    err_msg=f"Unable to parse event and no mapping found for topic {topic}",
+                    exc=e,
+                )
             return
 
         handler = self._config.event_handler_map.get(event.name)
@@ -154,7 +168,7 @@ class _KafkaConsumerHandlerMixin:
                     )
                     return
                 else:
-                    self._handle_retry(event=event)
+                    self._handle_retry(msg=msg,event=event)
                     return
 
             if response.dlq:


### PR DESCRIPTION
1. Added new config topic_event_name_map in KafkaConsumerConfig to map Kafka topics → event names.
2. Enhanced message parsing — if a message isn’t a valid Event, it’s now wrapped into an Event using this mapping.
3. Unmapped raw messages are sent to DLQ instead of crashing the consumer.
4. Fixed _handle_retry to correctly pass both msg and event.